### PR TITLE
ci: add fmt and clippy to ci workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -58,23 +58,3 @@ jobs:
 
       - name: Run rustfmt 
         run: cargo fmt --all --check
-
-
-  taplo-fmt:
-    runs-on: ubuntu-latest
-
-    steps:
-      - uses: actions/checkout@v4
-
-      - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@nightly
-        with:
-          toolchain: $(cat rust-toolchain)
-          components: rustfmt, clippy
-
-
-      - name: Install taplo-cli
-        run: cargo install --force --git https://github.com/tamasfe/taplo taplo-cli --no-default-features
-
-      - name: taplo fmt
-        run: taplo fmt --check

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,10 +20,10 @@ jobs:
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@nightly
         with:
-          toolchain: ${cat rust-toolchain}
+          toolchain: $(cat rust-toolchain)
           components: rustfmt, clippy
 
-      - name: Test (compile)
+      - name: Compile
         run: cargo test --no-run
 
       - name: Test
@@ -38,7 +38,7 @@ jobs:
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@nightly
         with:
-          toolchain: ${cat rust-toolchain}
+          toolchain: $(cat rust-toolchain)
           components: rustfmt, clippy
 
       - name: Run clippy 
@@ -53,7 +53,7 @@ jobs:
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@nightly
         with:
-          toolchain: ${cat rust-toolchain}
+          toolchain: $(cat rust-toolchain)
           components: rustfmt, clippy
 
       - name: Run rustfmt 
@@ -61,15 +61,15 @@ jobs:
 
 
   taplo-fmt:
-    needs: check-runner
-    runs-on: ${{ needs.check-runner.outputs.runner-label }}
+    runs-on: ubuntu-latest
+
     steps:
       - uses: actions/checkout@v4
 
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@nightly
         with:
-          toolchain: ${cat rust-toolchain}
+          toolchain: $(cat rust-toolchain)
           components: rustfmt, clippy
 
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,27 +11,70 @@ env:
   CARGO_TERM_COLOR: always
 
 jobs:
-  build:
+  test:
     runs-on: ubuntu-latest
-    timeout-minutes: 150 # Consider increasing timeout
-    strategy:
-      fail-fast: false
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
-      - uses: actions-rs/toolchain@v1
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@nightly
         with:
-          profile: minimal
-          toolchain: nightly
-          override: true
-          components: clippy
+          toolchain: ${cat rust-toolchain}
+          components: rustfmt, clippy
 
-      - name: Build
-        uses: actions-rs/cargo@v1
-        with:
-          command: build
-          args: --all --verbose
+      - name: Test (compile)
+        run: cargo test --no-run
 
       - name: Test
-        run: cargo test --all --verbose
+        run: cargo test --all --verbose --no-fail-fast
+
+  clippy:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@nightly
+        with:
+          toolchain: ${cat rust-toolchain}
+          components: rustfmt, clippy
+
+      - name: Run clippy 
+        run: cargo clippy --all-features --all-targets -- -D warnings
+
+  cargo-fmt:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@nightly
+        with:
+          toolchain: ${cat rust-toolchain}
+          components: rustfmt, clippy
+
+      - name: Run rustfmt 
+        run: cargo fmt --all --check
+
+
+  taplo-fmt:
+    needs: check-runner
+    runs-on: ${{ needs.check-runner.outputs.runner-label }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@nightly
+        with:
+          toolchain: ${cat rust-toolchain}
+          components: rustfmt, clippy
+
+
+      - name: Install taplo-cli
+        run: cargo install --force --git https://github.com/tamasfe/taplo taplo-cli --no-default-features
+
+      - name: taplo fmt
+        run: taplo fmt --check


### PR DESCRIPTION
Added the above in separate jobs as well as changed the test step a bit.

For tests, we separate compilation step with test step: see this [post](https://matklad.github.io/2021/09/04/fast-rust-builds.html#CI-Workflow) for justification.

Add very basic fmt and clippy checks, ~as well as taplo-fmt which checks the formatting of toml files.~ taplo is acting weird so i'm excluding it for now, rustfmt and clippy should be enough for now anyway.

ps: I also made the switch to dtolnay's ci action for cleaner syntax + actions/rs isn't really maintained anymore
